### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,22 @@ language: php
 
 sudo: false
 
-php:
-    - 7.1
-    - 7.0
-    - 5.6
-    - 5.5
-    - 5.4
-    - hhvm
-
 notifications:
     email: deploy@peter-gribanov.ru
 
 matrix:
     fast_finish: true
     include:
+        - php: 7.3
+        - php: 7.2
+        - php: 7.1
+        - php: 7.0
         - php: 5.6
           env: COVERAGE=1
-    allow_failures:
-        - php: hhvm
+        - php: 5.5
+          dist: trusty
+        - php: 5.4
+          dist: trusty
 
 before_install:
     - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$COVERAGE" != "1" ]; then phpenv config-rm xdebug.ini; fi;

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,13 @@
     },
     "require-dev": {
         "symfony/filesystem": "^2.4",
-        "phpunit/phpunit": "~4.8",
+        "phpunit/phpunit": "^4.8.36",
         "scrutinizer/ocular": "~1.3",
-        "satooshi/php-coveralls": "^1.0"
+        "php-coveralls/php-coveralls": "^1.0"
+    },
+    "suggest": {
+        "ext-zlib": "Support for Gzip compressor",
+        "ext-bz2": "Support for Bzip2 compressor",
+        "ext-zip": "Support for Zip compressor"
     }
 }

--- a/tests/Bzip2CompressorTest.php
+++ b/tests/Bzip2CompressorTest.php
@@ -10,8 +10,9 @@
 namespace GpsLab\Component\Compressor\Tests;
 
 use GpsLab\Component\Compressor\Bzip2Compressor;
+use PHPUnit\Framework\TestCase;
 
-class Bzip2CompressorTest extends \PHPUnit_Framework_TestCase
+class Bzip2CompressorTest extends TestCase
 {
     /**
      * @var Bzip2Compressor

--- a/tests/DummyCompressorTest.php
+++ b/tests/DummyCompressorTest.php
@@ -10,8 +10,9 @@
 namespace GpsLab\Component\Compressor\Tests;
 
 use GpsLab\Component\Compressor\DummyCompressor;
+use PHPUnit\Framework\TestCase;
 
-class DummyCompressorTest extends \PHPUnit_Framework_TestCase
+class DummyCompressorTest extends TestCase
 {
     /**
      * @var DummyCompressor

--- a/tests/GzipCompressorTest.php
+++ b/tests/GzipCompressorTest.php
@@ -10,8 +10,9 @@
 namespace GpsLab\Component\Compressor\Tests;
 
 use GpsLab\Component\Compressor\GzipCompressor;
+use PHPUnit\Framework\TestCase;
 
-class GzipCompressorTest extends \PHPUnit_Framework_TestCase
+class GzipCompressorTest extends TestCase
 {
     /**
      * @var GzipCompressor

--- a/tests/ZipCompressorTest.php
+++ b/tests/ZipCompressorTest.php
@@ -10,8 +10,9 @@
 namespace GpsLab\Component\Compressor\Tests;
 
 use GpsLab\Component\Compressor\ZipCompressor;
+use PHPUnit\Framework\TestCase;
 
-class ZipCompressorTest extends \PHPUnit_Framework_TestCase
+class ZipCompressorTest extends TestCase
 {
     /**
      * @var ZipCompressor


### PR DESCRIPTION
# Changed log
- Let all PHP version tests are on `matrix` block because it can let them use different dist development environment.
- Drop `php-5.4` version because it's very old and let this package require `php-5.5` version at least.
- Using the `PHPUnit\Framework\TestCase` to be compatible with future PHPUnit versions.
- Adding the suggest block on `composer.json` because it can notice developers every compressor should have different extensions.