### PR TITLE
Improve archive compressor tests

### DIFF
--- a/src/ZipCompressor.php
+++ b/src/ZipCompressor.php
@@ -38,9 +38,7 @@ class ZipCompressor implements CompressorInterface
             return false;
         }
 
-        if (false === $this->zip->addFile($source, basename($source))) {
-            $this->zip->close();
-
+        if (false === @$this->zip->addFile($source, basename($source))) {
             return false;
         }
 
@@ -59,9 +57,7 @@ class ZipCompressor implements CompressorInterface
             return false;
         }
 
-        if (false === $this->zip->extractTo(dirname($target), basename($target))) {
-            $this->zip->close();
-
+        if (false === @$this->zip->extractTo(dirname($target), basename($target))) {
             return false;
         }
 

--- a/tests/Bzip2CompressorTest.php
+++ b/tests/Bzip2CompressorTest.php
@@ -53,4 +53,19 @@ class Bzip2CompressorTest extends TestCase
         $this->assertTrue($this->fs->exists($uncompress));
         $this->assertTrue($this->fs->equals($uncompress));
     }
+
+    public function testCompressOnIncorrectFilePath()
+    {
+        $source = '/this/bzip/file/is/not/existed';
+
+        $this->assertFalse($this->compressor->compress($source));
+    }
+
+    public function testUncompressOnIncorrectFilePath()
+    {
+        $source = '/this/bzip/file/is/not/existed';
+        $target = '/this/target/bzip/file/is/not/existed';
+
+        $this->assertFalse($this->compressor->uncompress($source, $target));
+    }
 }

--- a/tests/GzipCompressorTest.php
+++ b/tests/GzipCompressorTest.php
@@ -51,4 +51,19 @@ class GzipCompressorTest extends TestCase
         $this->assertTrue($this->fs->exists($uncompress));
         $this->assertTrue($this->fs->equals($uncompress));
     }
+
+    public function testCompressOnIncorrectFilePath()
+    {
+        $source = '/this/bzip/file/is/not/existed';
+
+        $this->assertFalse($this->compressor->compress($source));
+    }
+
+    public function testUncompressOnIncorrectFilePath()
+    {
+        $source = '/this/bzip/file/is/not/existed';
+        $target = '/this/target/bzip/file/is/not/existed';
+
+        $this->assertFalse($this->compressor->uncompress($source, $target));
+    }
 }

--- a/tests/ZipCompressorTest.php
+++ b/tests/ZipCompressorTest.php
@@ -52,4 +52,19 @@ class ZipCompressorTest extends TestCase
         $this->assertTrue($this->fs->exists($source));
         $this->assertTrue($this->fs->equals($source));
     }
+
+    public function testCompressOnIncorrectFilePath()
+    {
+        $source = '/this/bzip/file/is/not/existed';
+
+        $this->assertFalse($this->compressor->compress($source));
+    }
+
+    public function testUncompressOnIncorrectFilePath()
+    {
+        $source = '/this/bzip/file/is/not/existed';
+        $target = '/this/target/bzip/file/is/not/existed';
+
+        $this->assertFalse($this->compressor->uncompress($source, $target));
+    }
 }


### PR DESCRIPTION
# Changed log
- Add `gzip` and `bzip` tests about compress and uncompress works have incorrect file path case.
- Let `ZipArchive::extractTo` and `ZipArchive::addFile` depress errors because it can avoid throwing exception.
- Removing `ZipArchive::close` because it will throw exception on these special situations.