### PR TITLE
Add PHP 7.4 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ notifications:
 matrix:
     fast_finish: true
     include:
+        - php: 7.4
         - php: 7.3
         - php: 7.2
         - php: 7.1


### PR DESCRIPTION
# Changed log
- Add `php-7.4` version test during Travis CI build.